### PR TITLE
Cicd/fix failing api publish

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -21,6 +21,7 @@ jobs:
       API_CSPROJ_PATH: src/DQRetro.TournamentTracker.Api/DQRetro.TournamentTracker.Api.csproj
       API_OUTPUT_FOLDER: ./DQRetro.TournamentTracker.Api
       DOTNET_CONFIGURATION: Release
+      IS_MAIN: ${{ github.ref == 'refs/heads/main' }}
     
     steps:
       - name: "Src: Checkout"
@@ -41,6 +42,7 @@ jobs:
         run: dotnet publish ${{ env.API_CSPROJ_PATH }} --configuration ${{ env.DOTNET_CONFIGURATION }} --no-restore --no-build --output ${{ env.API_OUTPUT_FOLDER }}
 
       - name: "Publish: API Artifact"
+        if: ${{ env.IS_MAIN == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: DQRetro.TournamentTracker.Api

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -2,8 +2,9 @@ name: Build & Publish API
 
 on:
   push:
-    branches:
-      - main
+    branches: # TODO: REVERT BRANCHES BEFORE PR!
+     - "cicd/fix-failing-api-publish"
+      # - main
 
 jobs:
   build:
@@ -25,18 +26,18 @@ jobs:
           dotnet-version: "9.0.x"
       
       - name: ".NET: Restore"
-        run: dotnet restore $API_CSPROJ_PATH
+        run: dotnet restore ${{ env.$API_CSPROJ_PATH }}
       
       - name: ".NET: Build"
-        run: dotnet build $API_CSPROJ_PATH --configuration $DOTNET_CONFIGURATION --no-restore
+        run: dotnet build ${{ env.$API_CSPROJ_PATH }} --configuration ${{ env.DOTNET_CONFIGURATION }} --no-restore
       
       - name: ".NET Publish"
-        run: dotnet publish $API_CSPROJ_PATH --configuration $DOTNET_CONFIGURATION --no-restore --no-build --output $API_OUTPUT_FOLDER
+        run: dotnet publish ${{ env.$API_CSPROJ_PATH }} --configuration ${{ env.DOTNET_CONFIGURATION }} --no-restore --no-build --output ${{ env.API_OUTPUT_FOLDER }}
 
       - name: "Publish: API Artifact"
         uses: actions/upload-artifact@v4
         with:
           name: DQRetro.TournamentTracker.Api
-          path: $API_OUTPUT_FOLDER
+          path: ${{ env.API_OUTPUT_FOLDER }}
           compression-level: 9 # Refers to ZLib compression levels (between 0(none) and 9(heavily compressed))
           if-no-files-found: error

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -2,9 +2,15 @@ name: Build & Publish API
 
 on:
   push:
-    branches: # TODO: REVERT BRANCHES BEFORE PR!
-     - "cicd/fix-failing-api-publish"
-      # - main
+    branches:
+     - main
+    paths:
+     - "src/DQRetro.TournamentTracker.Api/**"
+     - ".github/workflows/api.yml"
+  pull_request:
+    paths:
+     - "src/DQRetro.TournamentTracker.Api/**"
+     - ".github/workflows/api.yml"
 
 jobs:
   build:
@@ -31,7 +37,7 @@ jobs:
       - name: ".NET: Build"
         run: dotnet build ${{ env.API_CSPROJ_PATH }} --configuration ${{ env.DOTNET_CONFIGURATION }} --no-restore
       
-      - name: ".NET Publish"
+      - name: ".NET: Publish"
         run: dotnet publish ${{ env.API_CSPROJ_PATH }} --configuration ${{ env.DOTNET_CONFIGURATION }} --no-restore --no-build --output ${{ env.API_OUTPUT_FOLDER }}
 
       - name: "Publish: API Artifact"

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -26,13 +26,13 @@ jobs:
           dotnet-version: "9.0.x"
       
       - name: ".NET: Restore"
-        run: dotnet restore ${{ env.$API_CSPROJ_PATH }}
+        run: dotnet restore ${{ env.API_CSPROJ_PATH }}
       
       - name: ".NET: Build"
-        run: dotnet build ${{ env.$API_CSPROJ_PATH }} --configuration ${{ env.DOTNET_CONFIGURATION }} --no-restore
+        run: dotnet build ${{ env.API_CSPROJ_PATH }} --configuration ${{ env.DOTNET_CONFIGURATION }} --no-restore
       
       - name: ".NET Publish"
-        run: dotnet publish ${{ env.$API_CSPROJ_PATH }} --configuration ${{ env.DOTNET_CONFIGURATION }} --no-restore --no-build --output ${{ env.API_OUTPUT_FOLDER }}
+        run: dotnet publish ${{ env.API_CSPROJ_PATH }} --configuration ${{ env.DOTNET_CONFIGURATION }} --no-restore --no-build --output ${{ env.API_OUTPUT_FOLDER }}
 
       - name: "Publish: API Artifact"
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This PR contains the following changes:
 - Replace traditional variable replacement with a more standard YML based substitution syntax (fixes previous artifact publishing bug).
 - Only run the API Github Actions workflow on changes to "src/DQRetro.TournamentTracker.Api", or to the APIs worflow yml file.
 - Run on relevant Pull Requests, not just on main builds.