### PR TITLE
Fix/cors and videos controller naming

### DIFF
--- a/src/DQRetro.TournamentTracker.Api/Controllers/VideosController.cs
+++ b/src/DQRetro.TournamentTracker.Api/Controllers/VideosController.cs
@@ -6,11 +6,11 @@ namespace DQRetro.TournamentTracker.Api.Controllers;
 
 [ApiController]
 [Route("[controller]")]
-public sealed class VideoController : ControllerBase
+public sealed class VideosController : ControllerBase
 {
     private readonly IVideoService _videoService;
 
-    public VideoController(IVideoService videoService)
+    public VideosController(IVideoService videoService)
     {
         _videoService = videoService;
     }

--- a/src/DQRetro.TournamentTracker.Api/appsettings.json
+++ b/src/DQRetro.TournamentTracker.Api/appsettings.json
@@ -8,9 +8,10 @@
   "AllowedHosts": "*",
   "Cors": {
     "AllowedOrigins": [
-      "http://localhost:5173",
-      "http://127.0.0.1:5173",
-      "http://0.0.0.0:5173"
+      "https://dqretro.github.io/tekkenball-brackets",
+      "http://localhost:3000",
+      "http://127.0.0.1:3000",
+      "http:/192.168.0.25:3000"
     ]
   },
   "ForwardedHeaderOptions": {


### PR DESCRIPTION
This PR contains the following changes:
 - Update CORS allowed origins to allow the frontend to function.
 - Rename "VideoController" to "VideosController".