### PR TITLE
cicd: Force runtimeconfig to set Workstation GC

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -21,7 +21,8 @@ jobs:
       API_CSPROJ_PATH: src/DQRetro.TournamentTracker.Api/DQRetro.TournamentTracker.Api.csproj
       API_OUTPUT_FOLDER: ./DQRetro.TournamentTracker.Api
       DOTNET_CONFIGURATION: Release
-      IS_MAIN: ${{ github.ref == 'refs/heads/main' }}
+      DOTNET_SERVER_GC: false
+      IS_MAIN: ${{ github.ref == "refs/heads/main" }}
     
     steps:
       - name: "Src: Checkout"
@@ -39,7 +40,7 @@ jobs:
         run: dotnet build ${{ env.API_CSPROJ_PATH }} --configuration ${{ env.DOTNET_CONFIGURATION }} --no-restore
       
       - name: ".NET: Publish"
-        run: dotnet publish ${{ env.API_CSPROJ_PATH }} --configuration ${{ env.DOTNET_CONFIGURATION }} --no-restore --no-build --output ${{ env.API_OUTPUT_FOLDER }}
+        run: dotnet publish ${{ env.API_CSPROJ_PATH }} --configuration ${{ env.DOTNET_CONFIGURATION }} --no-restore --no-build --output ${{ env.API_OUTPUT_FOLDER }} /p:ServerGarbageCollection=${{ env.DOTNET_SERVER_GC }}
 
       - name: "Publish: API Artifact"
         if: ${{ env.IS_MAIN == 'true' }}


### PR DESCRIPTION
This PR contains the following changes:
 - Force the dotnet publish task to set workstation garbage collection mode.  This will likely result in slower response times under load, but aims to reduce overall memory usage.