### PR TITLE
cicd: Specify Workstation GC on build, as well as publish tasks

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -37,7 +37,7 @@ jobs:
         run: dotnet restore ${{ env.API_CSPROJ_PATH }}
       
       - name: ".NET: Build"
-        run: dotnet build ${{ env.API_CSPROJ_PATH }} --configuration ${{ env.DOTNET_CONFIGURATION }} --no-restore
+        run: dotnet build ${{ env.API_CSPROJ_PATH }} --configuration ${{ env.DOTNET_CONFIGURATION }} --no-restore /p:ServerGarbageCollection=${{ env.DOTNET_SERVER_GC }}
       
       - name: ".NET: Publish"
         run: dotnet publish ${{ env.API_CSPROJ_PATH }} --configuration ${{ env.DOTNET_CONFIGURATION }} --no-restore --no-build --output ${{ env.API_OUTPUT_FOLDER }} /p:ServerGarbageCollection=${{ env.DOTNET_SERVER_GC }}


### PR DESCRIPTION
The previous two PRs didn't quite work as intended.  I wanted to switch to workstation GC to reduce overall memory pressure (at the cost of increased latency under load).  It appears this dotnet argument needs to be passed into dotnet build and dotnet publish, not just dotnet publish.