### PR TITLE
fix: Missing '/' in URL scheme

### DIFF
--- a/src/DQRetro.TournamentTracker.Api/appsettings.json
+++ b/src/DQRetro.TournamentTracker.Api/appsettings.json
@@ -23,7 +23,7 @@
       "https://dqretro.github.io",
       "http://localhost:3000",
       "http://127.0.0.1:3000",
-      "http:/192.168.0.25:3000"
+      "http://192.168.0.25:3000"
     ]
   },
   "ForwardedHeaderOptions": {


### PR DESCRIPTION
This PR fixes:
 - CORS was still blocking one of the origins, the bug was caused by a missing '/' in 'http://'.