### PR TITLE
fix: Remove Kestrel server header

### DIFF
--- a/src/DQRetro.TournamentTracker.Api/Program.cs
+++ b/src/DQRetro.TournamentTracker.Api/Program.cs
@@ -28,6 +28,7 @@ public class Program
         builder.WebHost.ConfigureKestrel(kestrelServerOptions =>
         {
             kestrelServerOptions.Configure(builder.Configuration.GetRequiredSection("Kestrel"));
+            kestrelServerOptions.AddServerHeader = false;
         });
 
         bool isDevelopment = builder.Environment.IsDevelopment();
@@ -55,7 +56,7 @@ public class Program
         app.UseAuthorization();
         app.MapControllers();
         app.UseCustomSwagger(isDevelopment);
-        
+
         app.Services.GetRequiredService<ILogger<Program>>()
                     .LogInformation("Startup complete\n" +
                                     "ServerGc: {IsServerGc}\n" +


### PR DESCRIPTION
Ideally, we don't want to show any server details, which may make it easier for an attacker to perform reconnaissance on a given site/server.  Removing the server response header aims to reduce the visible surface of the API.  I had previously assumed this would have been overwritten by the reverse proxy's own server header, which turned out not to be the case.