### PR TITLE
feat: Add token bucket rate limiter

### DIFF
--- a/src/DQRetro.TournamentTracker.Api/Extensions/ResultExtensions.cs
+++ b/src/DQRetro.TournamentTracker.Api/Extensions/ResultExtensions.cs
@@ -22,6 +22,7 @@ public static class ResultExtensions
         const string timeoutErrorMessage = "Unable to access the requested resource in the allotted time frame.";
         const string sqlErrorMessage = "Unable to query the database.";
         const string featureNotImplementedMessage = "The requested feature has not been implemented.";
+        const string rateLimitExceededMessage = "You have exceeded the rate limit for this resource. Please try again later.";
 
         return code switch
         {
@@ -32,6 +33,7 @@ public static class ResultExtensions
             Code.TimeoutError => timeoutErrorMessage,
             Code.SqlError => sqlErrorMessage,
             Code.FeatureNotImplemented => featureNotImplementedMessage,
+            Code.RateLimitExceeded => rateLimitExceededMessage,
             _ => unknownErrorMessage
         };
     }
@@ -47,6 +49,7 @@ public static class ResultExtensions
             Code.TimeoutError => StatusCodes.Status408RequestTimeout,
             Code.SqlError => StatusCodes.Status500InternalServerError,
             Code.FeatureNotImplemented => StatusCodes.Status400BadRequest,
+            Code.RateLimitExceeded => StatusCodes.Status429TooManyRequests,
             _ => StatusCodes.Status500InternalServerError
         };
     }

--- a/src/DQRetro.TournamentTracker.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/src/DQRetro.TournamentTracker.Api/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,8 @@
 ﻿using System.Net;
+using System.Security.Claims;
 using System.Text.Json;
+using System.Threading.RateLimiting;
+using DQRetro.TournamentTracker.Api.Models.Common;
 using DQRetro.TournamentTracker.Api.Models.Configuration;
 using DQRetro.TournamentTracker.Api.Persistence.Database;
 using DQRetro.TournamentTracker.Api.Persistence.Database.Interfaces;
@@ -133,6 +136,49 @@ public static class ServiceCollectionExtensions
                              .AllowAnyHeader()
                              .AllowCredentials();
             });
+        });
+
+        return services;
+    }
+
+    /// <summary>
+    /// Adds a Token Bucket Rate Limiter for the API, with the aim of allowing fair usage of the API to legitimate requests.
+    /// Rate Limiting by UserId aims to prevent administrators from being blocked during tournaments, where multiple
+    /// users could, in theory, be accessing the API from the same IP Address.
+    /// </summary>
+    /// <param name="services"></param>
+    /// <returns></returns>
+    public static IServiceCollection AddTokenBucketRateLimiter(this IServiceCollection services)
+    {
+        services.AddRateLimiter(options =>
+        {
+            options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(context =>
+            {
+                string ipAddressKey = context?.Connection?.RemoteIpAddress?.ToString() ?? "Unknown";
+
+                // This looks weird, so what I want here is to allow a max of 20 requests in a 10-second period per user (determined by IP Address).
+                // Setting TokensPerPeriod to 20 and the ReplenishmentPeriod to 10 seconds would act like a fixed window limiter, which I don't want,
+                // as this will result in higher bursts.
+                // Instead, as an alternative, 20 requests in 10 seconds is equivalent to 2 requests per second.
+                // Therefore, as tokens are used up, we can start re-populating at a rate of 2 tokens per second.
+                // I don't want requests to be backed up, if a user is exceeding this limit, then drop their extra requests.
+                return RateLimitPartition.GetTokenBucketLimiter(ipAddressKey, _ => new TokenBucketRateLimiterOptions
+                {
+                    TokenLimit = 20,
+                    TokensPerPeriod = 2,
+                    ReplenishmentPeriod = TimeSpan.FromSeconds(1),
+                    QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                    QueueLimit = 0
+                });
+            });
+
+            options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+
+            options.OnRejected = async (context, token) =>
+            {
+                Error error = ResultExtensions.GetError(Code.RateLimitExceeded);
+                await context.HttpContext.Response.WriteAsJsonAsync(error, token);
+            };
         });
 
         return services;

--- a/src/DQRetro.TournamentTracker.Api/Models/Common/Code.cs
+++ b/src/DQRetro.TournamentTracker.Api/Models/Common/Code.cs
@@ -10,5 +10,6 @@ public enum Code
     TimeoutError = 4,
     SqlError = 5,
     FeatureNotImplemented = 6,
+    RateLimitExceeded = 7,
     #endregion
 }

--- a/src/DQRetro.TournamentTracker.Api/Program.cs
+++ b/src/DQRetro.TournamentTracker.Api/Program.cs
@@ -36,13 +36,12 @@ public class Program
         builder.Configuration.AddJsonFile("appsettings.json", optional: false, reloadOnChange: false);
         builder.Configuration.AddJsonFile("appsettings.Secrets.json", optional: false, reloadOnChange: false);
 
-        // TODO: ADD RATE LIMITING!
-
         builder.Services.AddCommonServices(builder.Configuration)
                         .AddVideoServices()
                         .AddDatabaseMigrations(isDevelopment)
                         .ConfigureForwardedHeaders(builder.Configuration, isDevelopment)
                         .AddCustomCors(builder.Configuration)
+                        .AddTokenBucketRateLimiter()
                         .AddCustomSwagger(builder.Configuration, isDevelopment)
                         .AddControllersWithCustomSerialization();
 
@@ -52,6 +51,7 @@ public class Program
         app.UseMiddleware<ExceptionHandlerMiddleware>();
         app.UseForwardedHeaders();
         app.UseCors();
+        app.UseRateLimiter();
         app.UseAuthentication();
         app.UseAuthorization();
         app.MapControllers();


### PR DESCRIPTION
This PR contains the following changes:
 - Add a rate limiter to the API, which allows for a maximum of 20 requests in 10 seconds, and refills at a rate of 2 requests per second.
 - This is currently applied at a global level (rate limit is shared across all API endpoints), and is per-IP though this may change to per-user in-future.