### PR TITLE
fix: Add another cors allowed origin whitelist

### DIFF
--- a/src/DQRetro.TournamentTracker.Api/appsettings.json
+++ b/src/DQRetro.TournamentTracker.Api/appsettings.json
@@ -23,7 +23,8 @@
       "https://dqretro.github.io",
       "http://localhost:3000",
       "http://127.0.0.1:3000",
-      "http://192.168.0.25:3000"
+      "http://192.168.0.25:3000",
+      "http://10.144.212.99:3000"
     ]
   },
   "ForwardedHeaderOptions": {


### PR DESCRIPTION
This PR includes the following changes:
 - Whitelist another IP Address within CORS:AllowedOrigins.