### PR TITLE
feat: refactor api and admin tools cli to manually populate video and…

### DIFF
--- a/src/DQRetro.TournamentTracker.Admin.Tools/Persistence/VideoAdminToolsYouTubeRepository.cs
+++ b/src/DQRetro.TournamentTracker.Admin.Tools/Persistence/VideoAdminToolsYouTubeRepository.cs
@@ -46,12 +46,8 @@ public sealed class VideoAdminToolsYouTubeRepository
         {
             videos.Add(new YouTubePlaylistVideo
             {
-                EventId = null,
                 Title = playlistVideo.Title,
                 YouTubeVideoId = playlistVideo.Id,
-                YouTubeVideoUrl = playlistVideo.Url,
-                YouTubeVideoThumbnailUrl = playlistVideo.Thumbnails.MaxBy(thumbnail => thumbnail.Resolution.Width * thumbnail.Resolution.Height).Url,
-                ReleaseDate = null
             });
         }
 

--- a/src/DQRetro.TournamentTracker.Admin.Tools/UserInteractions/Categories/Videos/CategoryItems/AddNewVideoChannelCategoryItem.cs
+++ b/src/DQRetro.TournamentTracker.Admin.Tools/UserInteractions/Categories/Videos/CategoryItems/AddNewVideoChannelCategoryItem.cs
@@ -59,11 +59,16 @@ public sealed class AddNewVideoChannelCategoryItem : ICategoryItem
 
         foreach (YouTubePlaylistVideo video in videosByPlaylist)
         {
+            // EventId is not currently supported and will be added at a later stage.
+            video.EventId = null;
+            video.ReleaseDate = null;
+            video.YouTubeVideoUrl = GetYouTubeVideoUrlFromYouTubeVideoId(video.YouTubeVideoId);
+            video.YouTubeVideoThumbnailUrl = GetYouTubeVideoThumbnailUrlFromYouTubeVideoId(video.YouTubeVideoId);
+
             Console.WriteLine($"Finding Release Date for \"{video.Title}\"");
             DateTime releaseDate = await _videoAdminToolsYouTubeRepository.GetReleaseDateFromVideoIdAsync(VideoId.Parse(video.YouTubeVideoId));
 
             Console.WriteLine($"Inserting video \"{video.Title}\" into the database...");
-            // EventId is not currently supported and will be added at a later stage.
             await _videoAdminToolsSqlRepository.InsertVideoAsync(videoChannelId, null, video.Title, video.YouTubeVideoId, video.YouTubeVideoUrl, video.YouTubeVideoThumbnailUrl, releaseDate);
         }
     }
@@ -84,5 +89,25 @@ public sealed class AddNewVideoChannelCategoryItem : ICategoryItem
 
             Console.WriteLine("Error: Input cannot be empty. Try again.");
         }
+    }
+
+    private static string GetYouTubeVideoUrlFromYouTubeVideoId(string videoId)
+    {
+        return $"https://youtu.be/{videoId}";
+    }
+
+    private static string GetYouTubeVideoThumbnailUrlFromYouTubeVideoId(string videoId)
+    {
+        // Available image quality options here are:
+        // default.jpg          120 x 90
+        // mqdefault.jpg        320 x 180
+        // hqdefault.jpg        480 x 360
+        // sddefault.jpg        640 x 480
+        // maxresdefault.jpg    1280 x 720 (can be lower than this, but this maxes out at 720p)
+
+        // As this will be returned to the UI in a grid, there's no point defaulting to the highest available resolution.
+        // hqdefault should be enough for now, but this can be changed here:
+        const string qualityOption = "hqdefault";
+        return $"https://img.youtube.com/vi/{videoId}/{qualityOption}.jpg";
     }
 }

--- a/src/DQRetro.TournamentTracker.Api/Persistence/YouTube/YouTubeExplodeRepository.cs
+++ b/src/DQRetro.TournamentTracker.Api/Persistence/YouTube/YouTubeExplodeRepository.cs
@@ -32,12 +32,8 @@ public sealed class YouTubeExplodeRepository : IYouTubeRepository
         {
             videos.Add(new VideosByPlaylistResponse
             {
-                EventId = null,
                 Title = playlistVideo.Title,
-                YouTubeVideoId = playlistVideo.Id,
-                YouTubeVideoUrl = playlistVideo.Url,
-                YouTubeVideoThumbnailUrl = playlistVideo.Thumbnails.MaxBy(thumbnail => thumbnail.Resolution.Width * thumbnail.Resolution.Height).Url,
-                ReleaseDate = null
+                YouTubeVideoId = playlistVideo.Id
             });
         }
 

--- a/src/DQRetro.TournamentTracker.Api/Services/Video/VideoService.cs
+++ b/src/DQRetro.TournamentTracker.Api/Services/Video/VideoService.cs
@@ -65,6 +65,12 @@ public sealed class VideoService : IVideoService
 
                 foreach (VideosByPlaylistResponse video in videosByChannelId)
                 {
+                    // EventId is not currently supported and will be added at a later stage.
+                    video.EventId = null;
+                    video.ReleaseDate = null;
+                    video.YouTubeVideoUrl = GetYouTubeVideoUrlFromYouTubeVideoId(video.YouTubeVideoId);
+                    video.YouTubeVideoThumbnailUrl = GetYouTubeVideoThumbnailUrlFromYouTubeVideoId(video.YouTubeVideoId);
+
                     AddEventVideoUpsertTvpDataRowToDataTable(upsertDataTable,
                                                              channel.Id,
                                                              video.Title,
@@ -109,6 +115,26 @@ public sealed class VideoService : IVideoService
         row[YouTubeVideoThumbnailUrl] = youTubeVideoThumbnailUrl;
 
         upsertDataTable.Rows.Add(row);
+    }
+
+    private static string GetYouTubeVideoUrlFromYouTubeVideoId(string videoId)
+    {
+        return $"https://youtu.be/{videoId}";
+    }
+
+    private static string GetYouTubeVideoThumbnailUrlFromYouTubeVideoId(string videoId)
+    {
+        // Available image quality options here are:
+        // default.jpg          120 x 90
+        // mqdefault.jpg        320 x 180
+        // hqdefault.jpg        480 x 360
+        // sddefault.jpg        640 x 480
+        // maxresdefault.jpg    1280 x 720 (can be lower than this, but this maxes out at 720p)
+
+        // As this will be returned to the UI in a grid, there's no point defaulting to the highest available resolution.
+        // hqdefault should be enough for now, but this can be changed here:
+        const string qualityOption = "hqdefault";
+        return $"https://img.youtube.com/vi/{videoId}/{qualityOption}.jpg";
     }
 
     private async Task UpsertEventVideosChunkIfRequiredAsync(DataTable dataTable, bool forced = false)

--- a/src/DQRetro.TournamentTracker.Db/Migrations/Script0002 - EventVideo Modifications.sql
+++ b/src/DQRetro.TournamentTracker.Db/Migrations/Script0002 - EventVideo Modifications.sql
@@ -24,8 +24,8 @@ GO
 CREATE TYPE [dbo].[EventVideoUpsertTvp] AS TABLE ([VideoChannelId]      SMALLINT      NOT NULL,
                                                   [Title]               NVARCHAR(128) NOT NULL,
                                                   [YouTubeVideoId]      VARCHAR(16)   NOT NULL,
-                                                  [YouTubeVideoUrl]     VARCHAR(256)  NOT NULL,
-                                                  [YouTubeThumbnailUrl] VARCHAR(256)  NOT NULL,
+                                                  [YouTubeVideoUrl]     VARCHAR(32)   NOT NULL,
+                                                  [YouTubeThumbnailUrl] VARCHAR(64)   NOT NULL,
                                                   PRIMARY KEY CLUSTERED ([YouTubeVideoId]));
 GO
 GRANT EXECUTE

--- a/src/DQRetro.TournamentTracker.Db/dbo/Tables/EventVideo.sql
+++ b/src/DQRetro.TournamentTracker.Db/dbo/Tables/EventVideo.sql
@@ -4,8 +4,8 @@ CREATE TABLE [dbo].[EventVideo] (
     [EventId]             SMALLINT                          NULL,
     [Title]               NVARCHAR(128)                 NOT NULL,
     [YouTubeVideoId]      VARCHAR(16)                   NOT NULL,
-    [YouTubeVideoUrl]     VARCHAR(256)                  NOT NULL,
-    [YouTubeThumbnailUrl] VARCHAR(256)                  NOT NULL,
+    [YouTubeVideoUrl]     VARCHAR(32)                   NOT NULL,
+    [YouTubeThumbnailUrl] VARCHAR(64)                   NOT NULL,
     [ReleaseDate]         DATETIME                          NULL,
     [ExcludedOn]          DATETIME                          NULL, 
     CONSTRAINT [PK_EventVideo] PRIMARY KEY CLUSTERED ([Id] ASC)


### PR DESCRIPTION
This PR contains the following:
 - Manually create the Video thumbnail, instead of relying on YouTubeExplode, as YouTubeExplode ends up picking longer URLs than necessary.
 - Update relevant column lengths in the EventVideo table.