### PR TITLE
chore: Bump SqlClient, Swagger & YouTubeExplode versions

### DIFF
--- a/src/DQRetro.TournamentTracker.Admin.Tools/DQRetro.TournamentTracker.Admin.Tools.csproj
+++ b/src/DQRetro.TournamentTracker.Admin.Tools/DQRetro.TournamentTracker.Admin.Tools.csproj
@@ -10,8 +10,8 @@
 
     <ItemGroup>
       <PackageReference Include="Dapper" Version="2.1.66" />
-      <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.1" />
-      <PackageReference Include="YoutubeExplode" Version="6.5.4" />
+      <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.2" />
+      <PackageReference Include="YoutubeExplode" Version="6.5.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/DQRetro.TournamentTracker.Api/DQRetro.TournamentTracker.Api.csproj
+++ b/src/DQRetro.TournamentTracker.Api/DQRetro.TournamentTracker.Api.csproj
@@ -9,9 +9,9 @@
     <ItemGroup>
         <PackageReference Include="Dapper" Version="2.1.66" />
         <PackageReference Include="dbup-sqlserver" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.1" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.4" />
-        <PackageReference Include="YoutubeExplode" Version="6.5.4" />
+        <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.2" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.6" />
+        <PackageReference Include="YoutubeExplode" Version="6.5.5" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This PR bumps dependency versions for the API and Admin Tools CLI for the following packages:
 - Microsoft.Data.SqlClient from 6.1.1 to 6.1.2
 - Swashbuckle.AspNetCore (Swagger) from 9.0.4 to 9.0.6
 - YouTubeExplode from 6.5.4 to 6.5.5